### PR TITLE
add missing pycryptodome to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ click==8.0.3
 lxml==4.7.1
 Pillow==9.1.1
 PTable==0.9.2
+pycryptodome==3.20.0
 pypdf==3.6.0
 text-unidecode==1.3


### PR DESCRIPTION
I tried using this script (which thank you, by the way!) and it initially complained about a missing dependency.  Worked great after installing, so figured it was easy enough to add to the requirements.