### PR TITLE
Option to shorten file names if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are five options:
 
 - `--dry-run`: Simulates the split. Prints the filenames, but does not create any files. Useful when checking if the options have been set correctly.
 - `--depth INTEGER`: The level of depth at which the splits will occur. See figure 1 for a visual explanation. Default value is set to 1.
+- `--max-filename-length INTEGER` If set to anything but 0 (the default), created file names will not exceed this length.
 - `--regex TEXT`: Selects outline items that match a RegEx pattern. For example `--regex "^Chapter"` will only select outline items that start with the string `Chapter`.
 - `--overlap`: Overlaps split points. By default, if **Chapter 1** starts at page 1 and **Chapter 2** starts at page 10, `Chapter 1.pdf` will contain pages 1–9, and `Chapter 2.pdf` will contain pages 10–.... By including the `--overlap` option, `Chapter 1.pdf` will now contain pages 1–10, and `Chapter 2.pdf` will contain pages 10..., etc. This is a useful option, if a section can start in the middle of a page.
 - `--prefix TEXT`: Adds a prefix to the output filenames. Supports the `{n}` placeholder for an n-th item index. For example, `--prefix "CLRS_{n}_"` results in `CLRS_1_<name>.pdf`.

--- a/pdf_splitter.py
+++ b/pdf_splitter.py
@@ -212,6 +212,7 @@ def shorten_filename_if_required(filename: str, file_name_max_len: int = 25) -> 
     modified_file_name = filename
     if len(modified_file_name) > file_name_max_len:
         basename, ext = os.path.splitext(modified_file_name)
+        basename = basename.strip()
         modified_file_name = basename[:(file_name_max_len - len(ext))] + ext
     return modified_file_name
 

--- a/pdf_splitter.py
+++ b/pdf_splitter.py
@@ -194,12 +194,12 @@ def dry_run_toc_split(page_ranges: List[PageRange], prefix: str,  maximum_file_n
             else:
                 filename = f"{safe_filename(prefix)}{filename}"
 
-        filename = shorten_filename_if_required(filename, maximum_file_name_length)
+        filename = shorten_filename_if_required(filename + ".pdf", maximum_file_name_length)
         if item["page_range"][0] == item["page_range"][1]:
-            print(f"– {filename}.pdf (contains page {item['page_range'][0] + 1})")
+            print(f"– {filename} (contains page {item['page_range'][0] + 1})")
         else:
             print(
-                f"– {filename}.pdf (contains pages {item['page_range'][0] + 1}–{item['page_range'][1] + 1})"
+                f"– {filename} (contains pages {item['page_range'][0] + 1}–{item['page_range'][1] + 1})"
             )
 
 

--- a/pdf_splitter.py
+++ b/pdf_splitter.py
@@ -11,6 +11,8 @@ import pypdf
 @click.command()
 @click.option("--dry-run", is_flag=True, help="Simulate a split")
 @click.option("--depth", nargs=1, default=1, show_default=True, help="Split depth")
+@click.option("--max-filename-length", nargs=1 , default=0, show_default=True,
+              help="Maximum filename length. The default 0 indicates no limit.")
 @click.option(
     "--regex", nargs=1, help="Select outline items that match a RegEx pattern"
 )
@@ -21,7 +23,7 @@ import pypdf
     help="Filename prefix. Supports the {n} placeholder for an n-th item index.",
 )
 @click.argument("file")
-def main(dry_run: bool, depth: int, regex: str, overlap: bool, prefix: str, file: str):
+def main(dry_run: bool, depth: int, max_filename_length: int, regex: str, overlap: bool, prefix: str, file: str):
     if not os.path.exists(file):
         print(f"Error: File '{file}' does not exist.")
         sys.exit(1)
@@ -48,9 +50,9 @@ def main(dry_run: bool, depth: int, regex: str, overlap: bool, prefix: str, file
             print("No outline items match the current depth or RegEx.")
     else:
         if dry_run is True:
-            dry_run_toc_split(page_ranges, prefix)
+            dry_run_toc_split(page_ranges, prefix, max_filename_length)
         else:
-            split_pdf(pdf, page_ranges, prefix)
+            split_pdf(pdf, page_ranges, prefix, max_filename_length)
 
 
 class OutlineItem(TypedDict):
@@ -154,7 +156,7 @@ def get_page_ranges(
     return page_ranges
 
 
-def split_pdf(pdf: pypdf.PdfReader, page_ranges: List[PageRange], prefix: str):
+def split_pdf(pdf: pypdf.PdfReader, page_ranges: List[PageRange], prefix: str, maximum_file_name_length: int):
     width = len(str(len(page_ranges)))
     for i, page_range in enumerate(page_ranges):
         pdf_writer = pypdf.PdfWriter()
@@ -171,13 +173,14 @@ def split_pdf(pdf: pypdf.PdfReader, page_ranges: List[PageRange], prefix: str):
             else:
                 filename = f"{safe_filename(prefix)}{filename}"
 
+        filename = shorten_filename_if_required(filename, maximum_file_name_length)
         with open(filename, "wb") as output:
             pdf_writer.write(output)
 
         print(f"Created file '{filename}'")
 
 
-def dry_run_toc_split(page_ranges: List[PageRange], prefix: str):
+def dry_run_toc_split(page_ranges: List[PageRange], prefix: str,  maximum_file_name_length: int):
     print("With current options, the following PDF files would be created.\n")
 
     width = len(str(len(page_ranges)))
@@ -191,6 +194,7 @@ def dry_run_toc_split(page_ranges: List[PageRange], prefix: str):
             else:
                 filename = f"{safe_filename(prefix)}{filename}"
 
+        filename = shorten_filename_if_required(filename, maximum_file_name_length)
         if item["page_range"][0] == item["page_range"][1]:
             print(f"– {filename}.pdf (contains page {item['page_range'][0] + 1})")
         else:
@@ -201,6 +205,15 @@ def dry_run_toc_split(page_ranges: List[PageRange], prefix: str):
 
 def safe_filename(filename: str) -> str:
     return "".join(c for c in filename if c.isalnum() or c in (" ", ".", "_", "-"))
+
+def shorten_filename_if_required(filename: str, file_name_max_len: int = 25) -> str:
+    if file_name_max_len == 0:
+        return filename
+    modified_file_name = filename
+    if len(modified_file_name) > file_name_max_len:
+        basename, ext = os.path.splitext(modified_file_name)
+        modified_file_name = basename[:(file_name_max_len - len(ext))] + ext
+    return modified_file_name
 
 
 def filter_by_regex(input_list: List[PageRange], regex: str) -> List[PageRange]:

--- a/pdf_splitter.py
+++ b/pdf_splitter.py
@@ -212,8 +212,7 @@ def shorten_filename_if_required(filename: str, file_name_max_len: int = 25) -> 
     modified_file_name = filename
     if len(modified_file_name) > file_name_max_len:
         basename, ext = os.path.splitext(modified_file_name)
-        basename = basename.strip()
-        modified_file_name = basename[:(file_name_max_len - len(ext))] + ext
+        modified_file_name = basename[:(file_name_max_len - len(ext))].rstrip() + ext
     return modified_file_name
 
 


### PR DESCRIPTION
Sometimes (especially in conference proceedings), chapter names can be quite long. This often results in OSError exceptions as such long file names cannot be stored. This pull request introduces an option to set a maximum file length, cutting off any longer names.